### PR TITLE
feat: use env for booking notifications

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -16,6 +16,7 @@ Environment variables (common)
 - SANITY_API_TOKEN — write token for Sanity if server-side writes/previews are needed.
 - SMTP_HOST, SMTP_PORT, SMTP_USER, SMTP_PASS (or SMTP_PASSWORD) — SMTP credentials for nodemailer.
 - SMTP_FROM — From: address used in sent emails.
+- BOOKING_NOTIFICATION_EMAIL — recipient for booking and contact notifications.
 - QUOTE_ACCEPTANCE_SECRET — secret for validating acceptance links.
 - NEXT_SERVER_ACTIONS_ENCRYPTION_KEY — required if server actions encryption is used.
 - NEXT_PUBLIC_* — any public variables referenced by client code.

--- a/app/api/contact/route.ts
+++ b/app/api/contact/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import nodemailer from "nodemailer";
+import { getNotificationEmail } from "../../../lib/notification-email";
 
 export async function POST(request: Request) {
   try {
@@ -26,10 +27,12 @@ export async function POST(request: Request) {
       // continue - sendMail will fail with the same error and be caught below
     }
 
+    const notificationEmail = getNotificationEmail();
+
     // Email content
     const mailOptions = {
       from: process.env.SMTP_USER,
-      to: "studio@tukang.design",
+      to: notificationEmail,
       subject: `New Contact Form Submission from ${name}`,
       html: `
         <div style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto;">

--- a/app/api/send-notification/route.ts
+++ b/app/api/send-notification/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import nodemailer from "nodemailer";
+import { getNotificationEmail } from "../../../lib/notification-email";
 
 export async function POST(request: NextRequest) {
   try {
@@ -84,10 +85,12 @@ Submitted: ${new Date().toLocaleString()}
       console.error("SMTP transporter verification failed for send-notification:", verifyError);
     }
 
+    const notificationEmail = getNotificationEmail();
+
     // Send email
     const emailResult = await transporter.sendMail({
       from: `"Project Estimator" <${process.env.SMTP_USER}>`,
-      to: "studio@tukang.design",
+      to: notificationEmail,
       subject: `New Project Estimate: ${data.name} - ${
         data.region === "MY" ? "RM" : data.region === "SG" ? "S$" : "USD"
       } ${regionalPrices[

--- a/lib/notification-email.ts
+++ b/lib/notification-email.ts
@@ -1,0 +1,10 @@
+export function getNotificationEmail(): string {
+  const email = process.env.BOOKING_NOTIFICATION_EMAIL;
+  if (!email) {
+    console.warn(
+      "BOOKING_NOTIFICATION_EMAIL is not set. Using studio@tukang.design."
+    );
+    return "studio@tukang.design";
+  }
+  return email;
+}


### PR DESCRIPTION
## Summary
- add `BOOKING_NOTIFICATION_EMAIL` and use it for booking notifications
- centralize notification email fallback in a helper
- document `BOOKING_NOTIFICATION_EMAIL` in deployment guide

## Testing
- `npm test`
- `npm run lint` *(fails: Error while loading rule 'react/display-name': sourceCode.getAllComments is not a function)*
- `npm run type-check` *(fails: Type '{ types: { image: ({ value, }: { value: { asset?: { url: string; }; alt?: string; caption?: string; }; }) => React.JSX.Element; }; block: { h4: ({ children }: { children: React.ReactNode; }) => React.JSX.Element; normal: ({ children }: { children: React.ReactNode; }) => React.JSX.Element; }; marks: { ...; }; }' is not assignable to type 'Partial<PortableTextReactComponents>' — in `app/portfolio/[slug]/page-fixed.tsx`)*

------
https://chatgpt.com/codex/tasks/task_e_68bcf90608f48324a555d73c32784c1e